### PR TITLE
[shellTeMP] [UPDATE] & [FIX] 07/28/2018

### DIFF
--- a/Servers/eAmob-B Rev-304/eAthena (Trunk)/conf/motd.txt
+++ b/Servers/eAmob-B Rev-304/eAthena (Trunk)/conf/motd.txt
@@ -16,4 +16,5 @@
 // \_________________________________________________________________________/
 
 // Internal default is limited to 128 lines.  If you need more, you will need to modify the MOTD_LINE_SIZE definition in pc.c
+
 Welcome to eAthena SVN Version! Enjoy! Please report any bugs you find.

--- a/Servers/eAmob-C Rev-502/Addons Rev-502/Server Side/npc-addons/eAmod/ban_system.txt
+++ b/Servers/eAmob-C Rev-502/Addons Rev-502/Server Side/npc-addons/eAmod/ban_system.txt
@@ -19,14 +19,14 @@
 // | Description: A Banishment System developed exclusive to eAmod System     |
 // |--------------------------------------------------------------------------|
 // | Changelog:                                                               |
-// | 1.0 - Initial Script Developed [J3MK1]                                   |
-// | 1.1 - Corrections on some Syntax and Messages [J3MK1]                    |
-// | 1.2 - Added Global Offline Functions [shellTeMP]                         |
-// | 1.3 - Added Cutin and Sleep 10s to Banishment [J3MK1]                    | 
-// | 1.4 - Corrections on some Syntax and Messages [J3MK1]                    |
-// | 1.5 - Add some Messages [J3MK1]                                          |
-// | 1.6 - Corrections in the Offline Jailing and Ban System [shellTeMP]      |
-// | 1.7 - Corrected in the Mute System [J3MK1]                               |
+// | 1.0 - Initial Script Developed. [J3MK1]                                  |
+// | 1.1 - Corrections on some Syntax and Messages. [J3MK1]                   |
+// | 1.2 - Added Global Offline Functions. [shellTeMP]                        |
+// | 1.3 - Added Cutin and Sleep 10s to Banishment. [J3MK1]                   | 
+// | 1.4 - Corrections on some Syntax and Messages. [J3MK1]                   |
+// | 1.5 - Add some Messages. [J3MK1]                                         |
+// | 1.6 - Corrections in the Offline Jailing and Ban System. [shellTeMP]     |
+// | 1.7 - Corrected in the Mute System. [J3MK1]                              |
 // \_________________________________________________________________________/
 
 -	script	eamodcmdban	-1,{

--- a/Servers/eAmob-C Rev-502/eAthena (Classic) (Trunk)/conf/motd.txt
+++ b/Servers/eAmob-C Rev-502/eAthena (Classic) (Trunk)/conf/motd.txt
@@ -15,4 +15,5 @@
 // \_________________________________________________________________________/
 
 // Internal default is limited to 128 lines.  If you need more, you will need to modify the MOTD_LINE_SIZE definition in pc.c
+
 Welcome to eAthena SVN Version! Enjoy! Please report any bugs you find.

--- a/Servers/eAmob-C Rev-502/eAthena (Trunk)/conf/motd.txt
+++ b/Servers/eAmob-C Rev-502/eAthena (Trunk)/conf/motd.txt
@@ -15,4 +15,5 @@
 // \_________________________________________________________________________/
 
 // Internal default is limited to 128 lines.  If you need more, you will need to modify the MOTD_LINE_SIZE definition in pc.c
+
 Welcome to eAthena SVN Version! Enjoy! Please report any bugs you find.


### PR DESCRIPTION
[UPDATE] Header of the eAmod Ban System inside “Addons Rev-502/Server Side/npc-addons/eAmod/”
[FIX] Message of the Day (motd.txt) files from eAthena versions inside “eAmob-C Rev-502” and “eAmob-B Rev-304”.