### PR TITLE
[J3MK1] [ADD] [FIX]  eAmod Support All Maps & NPC Announcer 08/06/2018

### DIFF
--- a/Servers/eAmob-A Rev-471/Addons Rev-471/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_announcer_lvl.txt
+++ b/Servers/eAmob-A Rev-471/Addons Rev-471/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_announcer_lvl.txt
@@ -19,25 +19,23 @@
 // | Description: An NPC who will announce when a player reaches level 99.    |
 // |--------------------------------------------------------------------------|
 // | Changelog:                                                               |
-// | 1.0 - Initial Script Developed.                                          |
-// | 1.1 - Fix some Syntax                                                    |
+// | 1.0 - Initial Script Developed. [J3MK1]                                  |
+// | 1.1 - Fix some Syntaxs [ShellTemp]                                       |
+// | 1.2 - Fix some Syntaxs [J3MK1]                                           |
 // \_________________________________________________________________________/
 
 -	script	AnBaseLv	-1,{
 
-	OnInit:
-	
-			set .MaxLvl, 99;
-	
+
 	OnPcBaseLvUpEvent:
 
 					if (BaseLevel==.MaxLvl) {
-
 							announce "Congratulations to "+ strcharinfo(0)+",  the player  just reached the level "+.MaxLvl+"!! ~",0;
-
 					}
 					end;
-
+	OnInit:
+	
+			set .MaxLvl, 99;
 
 }
 

--- a/Servers/eAmob-A Rev-471/Addons Rev-471/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_support_all_maps.txt
+++ b/Servers/eAmob-A Rev-471/Addons Rev-471/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_support_all_maps.txt
@@ -1,0 +1,100 @@
+//  __________________________________________________________________________
+// /                                                                          \
+// |                           _                                              |
+// |                          / \                         _                   |
+// |                  ___    / _ \   _ __ ___   ____  ___| |                  |
+// |                 / _ \  / /_\ \ | '_ ` _ \./  _ \/  _  |                  |
+// |                |  __/ /  ___  \| | | | | |  (_) ) (_) |                  |
+// |                 \___|/__/   \__\_| |_| |_|\____/\_____/                  |
+// |                                                                          |
+// |                              eAmod Script                                |
+// |                                                                          |
+// |--------------------------------------------------------------------------|
+// | Script Name: NPC Support                                                 |
+// |--------------------------------------------------------------------------|
+// | Created by: J3MK1 & ShellTemp                                            |
+// |--------------------------------------------------------------------------|
+// | Versions eASU/eA/brA/Herc/rA: all/all                                    |
+// |--------------------------------------------------------------------------|
+// | Description: NPC Normal Buffer (HEAL)                                    |
+// |              NPC VIP Buffer (HEAL, AGI, BLESS)                           |
+// |--------------------------------------------------------------------------|
+// | Changelog:                                                               |
+// | 1.0 - Initial Script Developed.                                          |
+// \_________________________________________________________________________/
+
+
+-	script	Support	-1,{
+
+	mes "[Support]";
+	mes "Hello! Would you like to receive what kind of buffs?";
+	next;
+	switch(select("- Normal Buffs:- VIP Buffs")){
+							case 1:
+									mes "[Support]";
+									mes "Ready! Good Up!";
+									percentheal 100,100;
+									emotion 10;
+									close;
+							case 2:
+									if(getgroupid() < 1 ) {
+											next;
+											mes "[Support]";
+											mes "Sorry, you must be a VIP player to receive the following buffs: Heal, Blessing, Agility and Debuff Stats";
+											close;
+        }
+ 
+
+									set .@now, gettimetick(2);
+									if( .@now < vip_delay ) {	
+											dispbottom "You still have "+(vip_delay - .@now)+" seconds left before you can use the Buffer again!";
+											close;
+											end;
+									} else {
+											mes "[Support]";
+											mes "Ready! Good Up!";
+											sc_start SC_INCREASEAGI,360000,10;
+											sc_start SC_BLESSING,360000,10;
+											sc_end SC_FREEZE;
+											sc_end SC_STONE;
+											sc_end SC_SLEEP;
+											sc_end SC_CURSE;
+											sc_end SC_CONFUSION;
+											sc_end SC_BLIND;
+											sc_end SC_BLEEDING;
+											sc_end SC_DECREASEAGI;
+											sc_end SC_POISON;
+											sc_end SC_HALLUCINATION;
+											sc_end SC_STRIPWEAPON;
+											sc_end SC_STRIPARMOR;
+											sc_end SC_STRIPSHIELD;
+											sc_end SC_STRIPHELM;
+											percentheal 100,100;
+											emotion 10;				
+											set vip_delay, gettimetick(2) + 600; // Delay of 10 min in seconds
+											close;
+											end;
+									}
+	}
+}
+//---------------------------------------------------------------------|
+// Duplicate Support All Maps                                          |
+//---------------------------------------------------------------------|
+pay_fild07,304,338,3	duplicate(Support)	Support#pay1	952
+pay_fild09,38,100,3	duplicate(Support)	Support#pay2	952
+pay_fild08,49,86,3	duplicate(Support)	Support#pay3	952
+gef_fild10,61,327,6	duplicate(Support)	Support#gef1	952
+gef_fild06,214,60,3	duplicate(Support)	Support#gef2	952
+moc_fild17,151,253,3	duplicate(Support)	Support#moc1	952
+moc_fild17,226,352,3	duplicate(Support)	Support#moc2	952
+in_sphinx4,15,217,3	duplicate(Support)	Support#moc3	952
+ra_fild12,46,219,3	duplicate(Support)	Support#ra1	952
+ra_fild04,267,66,3	duplicate(Support)	Support#ra2	952
+ra_fild05,196,202,3	duplicate(Support)	Support#ra3	952
+glast_01,359,305,3	duplicate(Support)	Support#gh1	952
+glast_01,204,131,3	duplicate(Support)	Support#gh2	952
+glast_01,204,290,3	duplicate(Support)	Support#gh3	952
+gl_prison,17,73,3	duplicate(Support)	Support#gl1	952
+gl_prison,146,176,3	duplicate(Support)	Support#gl2	952
+gl_sew03,280,296,3	duplicate(Support)	Support#gl36	952
+ayo_fild02,277,153,3	duplicate(Support)	Support#ayo1	952

--- a/Servers/eAmob-B Rev-304/Addons Rev-304/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_announcer_lvl.txt
+++ b/Servers/eAmob-B Rev-304/Addons Rev-304/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_announcer_lvl.txt
@@ -19,25 +19,23 @@
 // | Description: An NPC who will announce when a player reaches level 99.    |
 // |--------------------------------------------------------------------------|
 // | Changelog:                                                               |
-// | 1.0 - Initial Script Developed.                                          |
-// | 1.1 - Fix some Syntax                                                    |
+// | 1.0 - Initial Script Developed. [J3MK1]                                  |
+// | 1.1 - Fix some Syntaxs [ShellTemp]                                       |
+// | 1.2 - Fix some Syntaxs [J3MK1]                                           |
 // \_________________________________________________________________________/
 
 -	script	AnBaseLv	-1,{
 
-	OnInit:
-	
-			set .MaxLvl, 99;
-	
+
 	OnPcBaseLvUpEvent:
 
 					if (BaseLevel==.MaxLvl) {
-
 							announce "Congratulations to "+ strcharinfo(0)+",  the player  just reached the level "+.MaxLvl+"!! ~",0;
-
 					}
 					end;
-
+	OnInit:
+	
+			set .MaxLvl, 99;
 
 }
 

--- a/Servers/eAmob-B Rev-304/Addons Rev-304/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_support_all_maps.txt
+++ b/Servers/eAmob-B Rev-304/Addons Rev-304/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_support_all_maps.txt
@@ -1,0 +1,100 @@
+//  __________________________________________________________________________
+// /                                                                          \
+// |                           _                                              |
+// |                          / \                         _                   |
+// |                  ___    / _ \   _ __ ___   ____  ___| |                  |
+// |                 / _ \  / /_\ \ | '_ ` _ \./  _ \/  _  |                  |
+// |                |  __/ /  ___  \| | | | | |  (_) ) (_) |                  |
+// |                 \___|/__/   \__\_| |_| |_|\____/\_____/                  |
+// |                                                                          |
+// |                              eAmod Script                                |
+// |                                                                          |
+// |--------------------------------------------------------------------------|
+// | Script Name: NPC Support                                                 |
+// |--------------------------------------------------------------------------|
+// | Created by: J3MK1 & ShellTemp                                            |
+// |--------------------------------------------------------------------------|
+// | Versions eASU/eA/brA/Herc/rA: all/all                                    |
+// |--------------------------------------------------------------------------|
+// | Description: NPC Normal Buffer (HEAL)                                    |
+// |              NPC VIP Buffer (HEAL, AGI, BLESS)                           |
+// |--------------------------------------------------------------------------|
+// | Changelog:                                                               |
+// | 1.0 - Initial Script Developed.                                          |
+// \_________________________________________________________________________/
+
+
+-	script	Support	-1,{
+
+	mes "[Support]";
+	mes "Hello! Would you like to receive what kind of buffs?";
+	next;
+	switch(select("- Normal Buffs:- VIP Buffs")){
+							case 1:
+									mes "[Support]";
+									mes "Ready! Good Up!";
+									percentheal 100,100;
+									emotion 10;
+									close;
+							case 2:
+									if(getgroupid() < 1 ) {
+											next;
+											mes "[Support]";
+											mes "Sorry, you must be a VIP player to receive the following buffs: Heal, Blessing, Agility and Debuff Stats";
+											close;
+        }
+ 
+
+									set .@now, gettimetick(2);
+									if( .@now < vip_delay ) {	
+											dispbottom "You still have "+(vip_delay - .@now)+" seconds left before you can use the Buffer again!";
+											close;
+											end;
+									} else {
+											mes "[Support]";
+											mes "Ready! Good Up!";
+											sc_start SC_INCREASEAGI,360000,10;
+											sc_start SC_BLESSING,360000,10;
+											sc_end SC_FREEZE;
+											sc_end SC_STONE;
+											sc_end SC_SLEEP;
+											sc_end SC_CURSE;
+											sc_end SC_CONFUSION;
+											sc_end SC_BLIND;
+											sc_end SC_BLEEDING;
+											sc_end SC_DECREASEAGI;
+											sc_end SC_POISON;
+											sc_end SC_HALLUCINATION;
+											sc_end SC_STRIPWEAPON;
+											sc_end SC_STRIPARMOR;
+											sc_end SC_STRIPSHIELD;
+											sc_end SC_STRIPHELM;
+											percentheal 100,100;
+											emotion 10;				
+											set vip_delay, gettimetick(2) + 600; // Delay of 10 min in seconds
+											close;
+											end;
+									}
+	}
+}
+//---------------------------------------------------------------------|
+// Duplicate Support All Maps                                          |
+//---------------------------------------------------------------------|
+pay_fild07,304,338,3	duplicate(Support)	Support#pay1	952
+pay_fild09,38,100,3	duplicate(Support)	Support#pay2	952
+pay_fild08,49,86,3	duplicate(Support)	Support#pay3	952
+gef_fild10,61,327,6	duplicate(Support)	Support#gef1	952
+gef_fild06,214,60,3	duplicate(Support)	Support#gef2	952
+moc_fild17,151,253,3	duplicate(Support)	Support#moc1	952
+moc_fild17,226,352,3	duplicate(Support)	Support#moc2	952
+in_sphinx4,15,217,3	duplicate(Support)	Support#moc3	952
+ra_fild12,46,219,3	duplicate(Support)	Support#ra1	952
+ra_fild04,267,66,3	duplicate(Support)	Support#ra2	952
+ra_fild05,196,202,3	duplicate(Support)	Support#ra3	952
+glast_01,359,305,3	duplicate(Support)	Support#gh1	952
+glast_01,204,131,3	duplicate(Support)	Support#gh2	952
+glast_01,204,290,3	duplicate(Support)	Support#gh3	952
+gl_prison,17,73,3	duplicate(Support)	Support#gl1	952
+gl_prison,146,176,3	duplicate(Support)	Support#gl2	952
+gl_sew03,280,296,3	duplicate(Support)	Support#gl36	952
+ayo_fild02,277,153,3	duplicate(Support)	Support#ayo1	952

--- a/Servers/eAmob-C Rev-502/Addons Rev-502/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_announcer_lvl.txt
+++ b/Servers/eAmob-C Rev-502/Addons Rev-502/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_announcer_lvl.txt
@@ -19,25 +19,23 @@
 // | Description: An NPC who will announce when a player reaches level 99.    |
 // |--------------------------------------------------------------------------|
 // | Changelog:                                                               |
-// | 1.0 - Initial Script Developed.                                          |
-// | 1.1 - Fix some Syntax                                                    |
+// | 1.0 - Initial Script Developed. [J3MK1]                                  |
+// | 1.1 - Fix some Syntaxs [ShellTemp]                                       |
+// | 1.2 - Fix some Syntaxs [J3MK1]                                           |
 // \_________________________________________________________________________/
 
 -	script	AnBaseLv	-1,{
 
-	OnInit:
-	
-			set .MaxLvl, 99;
-	
+
 	OnPcBaseLvUpEvent:
 
 					if (BaseLevel==.MaxLvl) {
-
 							announce "Congratulations to "+ strcharinfo(0)+",  the player  just reached the level "+.MaxLvl+"!! ~",0;
-
 					}
 					end;
-
+	OnInit:
+	
+			set .MaxLvl, 99;
 
 }
 

--- a/Servers/eAmob-C Rev-502/Addons Rev-502/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_support_all_maps.txt
+++ b/Servers/eAmob-C Rev-502/Addons Rev-502/Server Side/eAmod-addons/npc-addons/custom/eAmod/English/eAmod_support_all_maps.txt
@@ -1,0 +1,100 @@
+//  __________________________________________________________________________
+// /                                                                          \
+// |                           _                                              |
+// |                          / \                         _                   |
+// |                  ___    / _ \   _ __ ___   ____  ___| |                  |
+// |                 / _ \  / /_\ \ | '_ ` _ \./  _ \/  _  |                  |
+// |                |  __/ /  ___  \| | | | | |  (_) ) (_) |                  |
+// |                 \___|/__/   \__\_| |_| |_|\____/\_____/                  |
+// |                                                                          |
+// |                              eAmod Script                                |
+// |                                                                          |
+// |--------------------------------------------------------------------------|
+// | Script Name: NPC Support                                                 |
+// |--------------------------------------------------------------------------|
+// | Created by: J3MK1 & ShellTemp                                            |
+// |--------------------------------------------------------------------------|
+// | Versions eASU/eA/brA/Herc/rA: all/all                                    |
+// |--------------------------------------------------------------------------|
+// | Description: NPC Normal Buffer (HEAL)                                    |
+// |              NPC VIP Buffer (HEAL, AGI, BLESS)                           |
+// |--------------------------------------------------------------------------|
+// | Changelog:                                                               |
+// | 1.0 - Initial Script Developed.                                          |
+// \_________________________________________________________________________/
+
+
+-	script	Support	-1,{
+
+	mes "[Support]";
+	mes "Hello! Would you like to receive what kind of buffs?";
+	next;
+	switch(select("- Normal Buffs:- VIP Buffs")){
+							case 1:
+									mes "[Support]";
+									mes "Ready! Good Up!";
+									percentheal 100,100;
+									emotion 10;
+									close;
+							case 2:
+									if(getgroupid() < 1 ) {
+											next;
+											mes "[Support]";
+											mes "Sorry, you must be a VIP player to receive the following buffs: Heal, Blessing, Agility and Debuff Stats";
+											close;
+        }
+ 
+
+									set .@now, gettimetick(2);
+									if( .@now < vip_delay ) {	
+											dispbottom "You still have "+(vip_delay - .@now)+" seconds left before you can use the Buffer again!";
+											close;
+											end;
+									} else {
+											mes "[Support]";
+											mes "Ready! Good Up!";
+											sc_start SC_INCREASEAGI,360000,10;
+											sc_start SC_BLESSING,360000,10;
+											sc_end SC_FREEZE;
+											sc_end SC_STONE;
+											sc_end SC_SLEEP;
+											sc_end SC_CURSE;
+											sc_end SC_CONFUSION;
+											sc_end SC_BLIND;
+											sc_end SC_BLEEDING;
+											sc_end SC_DECREASEAGI;
+											sc_end SC_POISON;
+											sc_end SC_HALLUCINATION;
+											sc_end SC_STRIPWEAPON;
+											sc_end SC_STRIPARMOR;
+											sc_end SC_STRIPSHIELD;
+											sc_end SC_STRIPHELM;
+											percentheal 100,100;
+											emotion 10;				
+											set vip_delay, gettimetick(2) + 600; // Delay of 10 min in seconds
+											close;
+											end;
+									}
+	}
+}
+//---------------------------------------------------------------------|
+// Duplicate Support All Maps                                          |
+//---------------------------------------------------------------------|
+pay_fild07,304,338,3	duplicate(Support)	Support#pay1	952
+pay_fild09,38,100,3	duplicate(Support)	Support#pay2	952
+pay_fild08,49,86,3	duplicate(Support)	Support#pay3	952
+gef_fild10,61,327,6	duplicate(Support)	Support#gef1	952
+gef_fild06,214,60,3	duplicate(Support)	Support#gef2	952
+moc_fild17,151,253,3	duplicate(Support)	Support#moc1	952
+moc_fild17,226,352,3	duplicate(Support)	Support#moc2	952
+in_sphinx4,15,217,3	duplicate(Support)	Support#moc3	952
+ra_fild12,46,219,3	duplicate(Support)	Support#ra1	952
+ra_fild04,267,66,3	duplicate(Support)	Support#ra2	952
+ra_fild05,196,202,3	duplicate(Support)	Support#ra3	952
+glast_01,359,305,3	duplicate(Support)	Support#gh1	952
+glast_01,204,131,3	duplicate(Support)	Support#gh2	952
+glast_01,204,290,3	duplicate(Support)	Support#gh3	952
+gl_prison,17,73,3	duplicate(Support)	Support#gl1	952
+gl_prison,146,176,3	duplicate(Support)	Support#gl2	952
+gl_sew03,280,296,3	duplicate(Support)	Support#gl36	952
+ayo_fild02,277,153,3	duplicate(Support)	Support#ayo1	952


### PR DESCRIPTION
1. Created Support All the Up Maps to Normal Players and Vip Players. Normal Players will received only heal and Vip Players will receive heal, bless, agi and debuff stats, but Vip Players will only be able to access all of these buffs again after 10 minutes passed since the first time they used the support. Script Tested and Closed #35.

2. I decided to test the NPC announcer again and found an error on the server (Script_rid2sd), error fixed. Fix #75